### PR TITLE
Updated safe id & error response body for known individual registration

### DIFF
--- a/app/controllers/stubs/RegistrationController.scala
+++ b/app/controllers/stubs/RegistrationController.scala
@@ -71,7 +71,9 @@ class RegistrationController @Inject()(repository: BusinessPartnerRepository,
             if (sap == "-1")
               Conflict
             else
-              Ok(Json.toJson(sap))
+              Ok(Json.obj(
+                "safeId" -> sap
+              ))
           }
 
           for {
@@ -110,7 +112,9 @@ class RegistrationController @Inject()(repository: BusinessPartnerRepository,
             if (sap == "-1")
               BadRequest
             else
-              Ok(Json.toJson(sap))
+              Ok(Json.obj(
+                "safeId" -> sap
+              ))
           }
 
           for {

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,7 +3,7 @@
 PUT         /tax-enrolments/subscriptions/:subscriptionId/issuer            @controllers.stubs.TaxEnrolmentsController.subscribeIssuer(subscriptionId: String)
 PUT         /tax-enrolments/subscriptions/:subscriptionId/subscriber        @controllers.stubs.TaxEnrolmentsController.subscribeSubscriber(subscriptionId: String)
 
-POST        /capital-gains-tax/individual/:nino/register                    @controllers.stubs.RegistrationController.registerBusinessPartner(nino: String)
+POST        /capital-gains-tax/registration/individual/nino/:nino           @controllers.stubs.RegistrationController.registerBusinessPartner(nino: String)
 GET         /capital-gains-tax/registration/details                         @controllers.stubs.RegistrationController.getExistingSAP(nino: String)
 
 POST        /capital-gains-tax/non-resident/individual/register             @controllers.stubs.GhostRegistrationController.registerBusinessPartner

--- a/test/controllers/stubs/RegistrationControllerSpec.scala
+++ b/test/controllers/stubs/RegistrationControllerSpec.scala
@@ -22,7 +22,7 @@ import models.{BusinessPartnerModel, RegisterModel, RouteExceptionKeyModel, Rout
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
-import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repositories.{BusinessPartnerRepository, CgtRepository, RouteExceptionRepository}


### PR DESCRIPTION
Also updated route to match API

Should be merged with Dave's refactor ob subscription backend (CGT-2944)